### PR TITLE
Add versioning control to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,30 @@ on:
   workflow_dispatch:
 
 jobs:
+#add controle de vercionamento
+  versionamento:
+    runs-on: ubuntu-latest
+    name: Versionamento
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0 #historico de commits, assim fazendo o recalculo da versão
+
+      - uses: codacy/git-version@2.8.0
+        with:
+          release-branch: main #podendo variar com main master
+          prefix: v
+
+      - name: Tag do repositorio
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::notice:: ${{ steps.git-version.outputs.version }}"
+
+
   build:
     runs-on: ubuntu-latest
     name: Build Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
        
   workflow_dispatch:
 
+permissions:
+  contents: write  # Adicione esta linha
+
 jobs:
 #add controle de vercionamento
   versionamento:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Tag do repositorio
         env:
-          GH_TOKEN: ${{ secrets.TESTE }}
+          #GH_TOKEN: ${{ secrets.TESTE }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "::notice:: ${{ steps.version.outputs.version }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0 #historico de commits, assim fazendo o recalculo da versão
 
       - uses: codacy/git-version@2.8.0
+        id: version
         with:
           release-branch: main #podendo variar com main master
           prefix: v
@@ -32,7 +33,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::notice:: ${{ steps.git-version.outputs.version }}"
+          echo "::notice:: ${{ steps.version.outputs.version }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
+          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push --tags
+          if: github.ref == 'refs/heads/main'
 
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
           git push --tags
-          if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
 
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Tag do repositorio
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TESTE }}
         run: |
           echo "::notice:: ${{ steps.version.outputs.version }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
Implement versioning control in the build workflow to manage version tags effectively. This includes steps for checking out the code and tagging the repository based on the version calculated.