### PR TITLE
Update build workflow permissions and formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,5 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
 
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,3 +111,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
       
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,10 +105,11 @@ jobs:
   dependecy-check:
     needs: versionamento
     runs-on: ubuntu-latest
-    name: verificação de dependencias
-    
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
-      
+
       


### PR DESCRIPTION
Add permissions for the dependency check job in the build workflow and ensure proper formatting by adding a newline at the end of the file.