### PR TITLE
Add base and head references to dependency check job in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,5 +113,8 @@ jobs:
       - uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
+          base-ref: main
+          head-ref: main
+          
 
       


### PR DESCRIPTION
Include base and head references in the dependency review action to enhance the verification process in the build workflow.